### PR TITLE
fix mochawesome-merge command

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -33,4 +33,4 @@ test:
         - 'npx cypress run --reporter mochawesome --reporter-options "reportDir=cypress/report/mochawesome-report,overwrite=false,html=false,json=true,timestamp=mmddyyyy_HHMMss"'
     postTest:
       commands:
-        - npx mochawesome-merge cypress/report/mochawesome-report > cypress/report/mochawesome.json
+        - npx mochawesome-merge cypress/report/mochawesome-report/*.json > cypress/report/mochawesome.json


### PR DESCRIPTION
npx mochawesome-merge cypress/report/mochawesome-report > cypress/report/mochawesome.json fails with this output:
npx: installed 17 in 1.532s
ERROR: Failed to merge reports

[Error: EISDIR: illegal operation on a directory, read] {
  errno: -21,
  code: 'EISDIR',
  syscall: 'read'
}